### PR TITLE
Align implementation to spec 1.0 of sidetree

### DIFF
--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -11,6 +11,7 @@ pub enum UpdateType {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct OperationRequestGenerated {
     pub r#type: String,
     pub suffix_data: SuffixData,
@@ -18,6 +19,7 @@ pub struct OperationRequestGenerated {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct DIDCreateResult {
     pub operation_request: OperationRequestGenerated,
     pub did_suffix: String,
@@ -26,6 +28,7 @@ pub struct DIDCreateResult {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct SignedDataPayload {
     pub update_key: JsonWebKey,
     pub delta_hash: String,
@@ -50,7 +53,7 @@ pub struct DidDocument {
     pub id: String,
     #[serde(rename = "@context")]
     pub context: Value,
-    pub key_agreement: Vec<KeyAgreement>,
+    pub verification_method: Option<Vec<KeyAgreement>>,
     pub service: Option<Vec<Service>>,
 }
 
@@ -67,8 +70,16 @@ pub struct KeyAgreement {
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DidDocumentMetadata {
-    pub recovery_commitment: String,
-    pub update_commitment: String,
+    pub method: MethodMetadata,
+    pub deactivated: Option<bool>,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MethodMetadata {
+    pub published: bool,
+    pub recovery_commitment: Option<String>,
+    pub update_commitment: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
@@ -81,6 +92,7 @@ pub struct Service {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct DidUpdatePayload {
     pub update_type: UpdateType,
     pub update_key: Option<JsonWebKey>,
@@ -91,6 +103,7 @@ pub struct DidUpdatePayload {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct DidCreateResponse {
     pub update_key: JsonWebKey,
     pub recovery_key: JsonWebKey,

--- a/src/vade_sidetree.rs
+++ b/src/vade_sidetree.rs
@@ -406,7 +406,7 @@ mod tests {
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         // then add a new public key to the DID
         let key_pair = secp256k1::KeyPair::random();
@@ -443,7 +443,7 @@ mod tests {
         };
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         // after update, resolve and check if there are 2 public keys in the DID document
         let result = did_handler
@@ -635,7 +635,7 @@ mod tests {
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         let service_endpoint = "https://w3id.org/did-resolution/v1".to_string();
 
@@ -724,7 +724,7 @@ mod tests {
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         let service_endpoint = "https://w3id.org/did-resolution/v1".to_string();
 
@@ -856,7 +856,7 @@ mod tests {
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(30000));
+        thread::sleep(Duration::from_millis(40000));
 
         // resolve DID
         let result = did_handler
@@ -916,7 +916,7 @@ mod tests {
             .await;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(30000));
+        thread::sleep(Duration::from_millis(40000));
 
         // try to resolve DID after recovery
         let result = did_handler
@@ -965,7 +965,7 @@ mod tests {
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         let update_payload = DidUpdatePayload {
             update_type: UpdateType::Deactivate,
@@ -987,7 +987,7 @@ mod tests {
         assert_eq!(result.is_ok(), true);
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
         // after update, resolve and check if the DID is deactivated
         let result = did_handler
             .did_resolve(&create_response.did.did_document.id)

--- a/src/vade_sidetree.rs
+++ b/src/vade_sidetree.rs
@@ -126,7 +126,6 @@ impl VadePlugin for VadeSidetree {
             .await?
             .text()
             .await?;
-        dbg!(&res);
         let response = DidCreateResponse {
             update_key: create_result.update_key,
             recovery_key: create_result.recovery_key,

--- a/src/vade_sidetree.rs
+++ b/src/vade_sidetree.rs
@@ -221,7 +221,6 @@ impl VadePlugin for VadeSidetree {
             Ok(value) => value,
             Err(err) => return Err(Box::from(format!("{}", err))),
         };
-        dbg!(serde_json::to_string(&update_output.operation_request)?);
         let res = client
             .post(api_url)
             .json(&update_output.operation_request)

--- a/src/vade_sidetree.rs
+++ b/src/vade_sidetree.rs
@@ -18,15 +18,13 @@ extern crate vade;
 
 use crate::datatypes::*;
 use async_trait::async_trait;
-use base64::encode_config;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::error::Error;
 use vade::{VadePlugin, VadePluginResultValue};
 use vade_sidetree_client::{
     did::JsonWebKey,
-    operations::{self, DeactivateOperationInput, Operation, OperationInput},
+    operations::{self, DeactivateOperationInput, OperationInput},
     operations::{RecoverOperationInput, UpdateOperationInput},
 };
 
@@ -119,22 +117,16 @@ impl VadePlugin for VadeSidetree {
         let mut api_url = self.config.sidetree_rest_api_url.clone();
         api_url.push_str("operations");
         let create_result: DIDCreateResult = serde_json::from_str(&json)?;
-        let suffix_data_base64 = &encode_config(
-            serde_json::to_string(&create_result.operation_request.suffix_data)?,
-            base64::STANDARD_NO_PAD,
-        );
-        let delta_base64 = &encode_config(
-            serde_json::to_string(&create_result.operation_request.delta)?,
-            base64::STANDARD_NO_PAD,
-        );
-        let mut map = HashMap::new();
-        map.insert("type", "create");
-        map.insert("suffix_data", suffix_data_base64);
-        map.insert("delta", delta_base64);
 
         let client = reqwest::Client::new();
-        let res = client.post(api_url).json(&map).send().await?.text().await?;
-
+        let res = client
+            .post(api_url)
+            .json(&create_result.operation_request)
+            .send()
+            .await?
+            .text()
+            .await?;
+        dbg!(&res);
         let response = DidCreateResponse {
             update_key: create_result.update_key,
             recovery_key: create_result.recovery_key,
@@ -168,7 +160,6 @@ impl VadePlugin for VadeSidetree {
 
         let mut operation_type: String = String::new();
         let mut api_url = self.config.sidetree_rest_api_url.clone();
-        let mut map = HashMap::new();
         let client = reqwest::Client::new();
 
         api_url.push_str("operations");
@@ -231,31 +222,14 @@ impl VadePlugin for VadeSidetree {
             Ok(value) => value,
             Err(err) => return Err(Box::from(format!("{}", err))),
         };
-
-        let res = match update_output.operation_request {
-            Operation::Update(did, delta, signed) | Operation::Recover(did, delta, signed) => {
-                let mut delta_base64 = String::new();
-                delta_base64.push_str(&encode_config(
-                    serde_json::to_string(&delta)?,
-                    base64::STANDARD_NO_PAD,
-                ));
-
-                map.insert("type", &operation_type);
-                map.insert("signed_data", &signed);
-                map.insert("did_suffix", &did);
-                map.insert("delta", &delta_base64);
-                client.post(api_url).json(&map).send().await?.text().await?
-            }
-
-            Operation::Deactivate(did, signed) => {
-                map.insert("type", &operation_type);
-                map.insert("signed_data", &signed);
-                map.insert("did_suffix", &did);
-
-                client.post(api_url).json(&map).send().await?.text().await?
-            }
-            _ => return Err(Box::from("Invalid operation")),
-        };
+        dbg!(serde_json::to_string(&update_output.operation_request)?);
+        let res = client
+            .post(api_url)
+            .json(&update_output.operation_request)
+            .send()
+            .await?
+            .text()
+            .await?;
 
         Ok(VadePluginResultValue::Success(Some(res)))
     }
@@ -309,7 +283,8 @@ mod tests {
         });
     }
 
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_create_did() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
@@ -323,7 +298,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_create_did_with_predefined_keys() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
@@ -351,7 +327,7 @@ mod tests {
 
         assert_eq!(result.is_ok(), true);
 
-        let result_value = match result? {
+        let result_value = match result {
             VadePluginResultValue::Success(Some(value)) => value.to_string(),
             _ => return Err(Box::from("Unknown Result".to_string())),
         };
@@ -371,7 +347,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_resolve_did() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
@@ -390,7 +367,7 @@ mod tests {
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         let result = did_handler
             .did_resolve(&create_response.did.did_document.id)
@@ -410,7 +387,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_update_did_add_public_keys() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
@@ -435,13 +413,14 @@ mod tests {
         // then add a new public key to the DID
         let key_pair = secp256k1::KeyPair::random();
         let update_key =
-            key_pair.to_public_key("update_key".into(), Some([Purpose::Agreement].to_vec()));
+            key_pair.to_public_key("update_key".into(), Some([Purpose::KeyAgreement].to_vec()));
 
         let patch: Patch = Patch::AddPublicKeys(vade_sidetree_client::AddPublicKeys {
             public_keys: vec![update_key.clone()],
         });
 
-        let update_commitment = multihash::canonicalize_then_double_hash_then_encode(&update_key)?;
+        let update_commitment =
+            multihash::canonicalize_then_double_hash_then_encode(&update_key.public_key_jwk)?;
 
         let update_payload = DidUpdatePayload {
             update_type: UpdateType::Update,
@@ -460,7 +439,7 @@ mod tests {
             )
             .await;
 
-        let _respone = match result? {
+        let _response = match result? {
             VadePluginResultValue::Success(Some(value)) => value.to_string(),
             _ => return Err(Box::from("Unknown Result".to_string())),
         };
@@ -479,37 +458,56 @@ mod tests {
         };
 
         let resolve_result: SidetreeDidDocument = serde_json::from_str(&did_resolve)?;
-        assert_eq!(resolve_result.did_document.key_agreement.len(), 1);
+        assert_eq!(
+            resolve_result.did_document.verification_method.is_some(),
+            true
+        );
+        assert_eq!(
+            resolve_result
+                .did_document
+                .verification_method
+                .unwrap()
+                .len(),
+            1
+        );
 
         Ok(())
     }
 
-    #[ignore]
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_update_did_remove_public_keys() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
+        let mut did_handler = VadeSidetree::new(std::env::var("SIDETREE_API_URL").ok());
 
-        let create_operation = operations::create(None);
-        let create_output = match create_operation {
-            Ok(value) => value,
-            Err(err) => return Err(Box::from(format!(" {}", err))),
+        // first create a new DID on sidetree
+        let result = did_handler
+            .did_create("did:evan", "{\"type\":\"sidetree\"}", "{}")
+            .await;
+        assert!(result.is_ok());
+
+        let response = match result? {
+            VadePluginResultValue::Success(Some(value)) => value.to_string(),
+            _ => return Err(Box::from("Unknown Result".to_string())),
         };
-        let json = serde_json::to_string(&create_output)?;
-        let create_response: DIDCreateResult = serde_json::from_str(&json)?;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
+        let create_response: DidCreateResponse = serde_json::from_str(&response)?;
+
+        // then add a new public key to the DID
         let key_pair = secp256k1::KeyPair::random();
         let update_key =
-            key_pair.to_public_key("update_key".into(), Some([Purpose::Agreement].to_vec()));
+            key_pair.to_public_key("update_key".into(), Some([Purpose::KeyAgreement].to_vec()));
 
-        let patch: Patch = Patch::RemovePublicKeys(vade_sidetree_client::RemovePublicKeys {
-            ids: vec!["update_key".to_string()],
+        let patch: Patch = Patch::AddPublicKeys(vade_sidetree_client::AddPublicKeys {
+            public_keys: vec![update_key.clone()],
         });
 
-        let update_commitment = multihash::canonicalize_then_double_hash_then_encode(&update_key)?;
+        let update_commitment =
+            multihash::canonicalize_then_double_hash_then_encode(&update_key.public_key_jwk)?;
 
         let update_payload = DidUpdatePayload {
             update_type: UpdateType::Update,
@@ -520,13 +518,72 @@ mod tests {
             recovery_key: None,
         };
 
-        let mut did_handler = VadeSidetree::new(std::env::var("SIDETREE_API_URL").ok());
         let result = did_handler
             .did_update(
-                &format!(
-                    "did:evan:{}",
-                    "EiC5_bIqTpMDGHBra-XnjoVV1r4mZwBt9pYNx8VaSaEZtQ"
-                ),
+                &create_response.did.did_document.id,
+                &"{\"type\":\"sidetree\"}",
+                &serde_json::to_string(&update_payload)?,
+            )
+            .await;
+
+        let _response = match result? {
+            VadePluginResultValue::Success(Some(value)) => value.to_string(),
+            _ => return Err(Box::from("Unknown Result".to_string())),
+        };
+
+        // Sleep is required to let the create or update operation take effect
+        thread::sleep(Duration::from_millis(40000));
+
+        // after update, resolve and check if there are 2 public keys in the DID document
+        let result = did_handler
+            .did_resolve(&create_response.did.did_document.id)
+            .await;
+
+        let did_resolve = match result? {
+            VadePluginResultValue::Success(Some(value)) => value.to_string(),
+            _ => return Err(Box::from("Unknown Result".to_string())),
+        };
+
+        let resolve_result: SidetreeDidDocument = serde_json::from_str(&did_resolve)?;
+        assert_eq!(
+            resolve_result.did_document.verification_method.is_some(),
+            true
+        );
+        assert_eq!(
+            resolve_result
+                .did_document
+                .verification_method
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // then remove the public key from the DID again
+        let new_key_pair = secp256k1::KeyPair::random();
+        let new_update_key = new_key_pair.to_public_key(
+            "new_update_key".into(),
+            Some([Purpose::KeyAgreement].to_vec()),
+        );
+
+        let patch: Patch = Patch::RemovePublicKeys(vade_sidetree_client::RemovePublicKeys {
+            ids: vec!["update_key".to_string()],
+        });
+
+        let update_commitment =
+            multihash::canonicalize_then_double_hash_then_encode(&new_update_key)?;
+
+        let update_payload = DidUpdatePayload {
+            update_type: UpdateType::Update,
+            update_key: Some(JsonWebKey::from(&key_pair)),
+            update_commitment: Some(update_commitment),
+            patches: Some(vec![patch]),
+            recovery_commitment: None,
+            recovery_key: None,
+        };
+
+        let result = did_handler
+            .did_update(
+                &format!("did:evan:{}", &create_response.did.did_document.id),
                 &"{\"type\":\"sidetree\"}",
                 &serde_json::to_string(&update_payload)?,
             )
@@ -538,10 +595,29 @@ mod tests {
             _ => return Err(Box::from("Unknown Result".to_string())),
         };
 
+        // Sleep is required to let the create or update operation take effect
+        thread::sleep(Duration::from_millis(40000));
+
+        // after update, resolve and check if there are 2 public keys in the DID document
+        let result = did_handler
+            .did_resolve(&create_response.did.did_document.id)
+            .await;
+
+        let did_resolve = match result? {
+            VadePluginResultValue::Success(Some(value)) => value.to_string(),
+            _ => return Err(Box::from("Unknown Result".to_string())),
+        };
+
+        let resolve_result: SidetreeDidDocument = serde_json::from_str(&did_resolve)?;
+        assert_eq!(
+            resolve_result.did_document.verification_method.is_some(),
+            false
+        );
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_update_did_add_service_endpoints() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
@@ -568,17 +644,20 @@ mod tests {
         let service = Service {
             id: "sds".to_string(),
             service_type: "SecureDataStrore".to_string(),
-            endpoint: service_endpoint.clone(),
+            service_endpoint: service_endpoint.clone(),
         };
 
-        let patch: Patch = Patch::AddServiceEndpoints(vade_sidetree_client::AddServices {
-            service_endpoints: vec![service],
+        let patch: Patch = Patch::AddServices(vade_sidetree_client::AddServices {
+            services: vec![service],
         });
 
-        let update_commitment = multihash::canonicalize_then_hash_then_encode(
-            &create_response.update_key,
-            multihash::HashAlgorithm::Sha256,
-        );
+        // then add a new public key to the DID
+        let key_pair = secp256k1::KeyPair::random();
+        let update_key =
+            key_pair.to_public_key("update_key".into(), Some([Purpose::KeyAgreement].to_vec()));
+
+        let update_commitment =
+            multihash::canonicalize_then_double_hash_then_encode(&update_key.public_key_jwk)?;
 
         let update_payload = DidUpdatePayload {
             update_type: UpdateType::Update,
@@ -597,10 +676,13 @@ mod tests {
             )
             .await;
 
-        assert_eq!(result.is_ok(), true);
+        let _response = match result? {
+            VadePluginResultValue::Success(Some(value)) => value.to_string(),
+            _ => return Err(Box::from("Unknown Result".to_string())),
+        };
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         // after update, resolve and check if there is the new added service
         let result = did_handler
@@ -623,7 +705,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_update_did_remove_services() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
@@ -650,21 +733,19 @@ mod tests {
         let service = Service {
             id: "sds".to_string(),
             service_type: "SecureDataStrore".to_string(),
-            endpoint: service_endpoint.clone(),
+            service_endpoint: service_endpoint.clone(),
         };
 
-        let patch: Patch = Patch::AddServiceEndpoints(vade_sidetree_client::AddServices {
-            service_endpoints: vec![service],
+        let patch: Patch = Patch::AddServices(vade_sidetree_client::AddServices {
+            services: vec![service],
         });
 
         let update1_key_pair = secp256k1::KeyPair::random();
         let mut update1_public_key: JsonWebKey = (&update1_key_pair).into();
         update1_public_key.d = None;
 
-        let update_commitment = multihash::canonicalize_then_hash_then_encode(
-            &update1_public_key,
-            multihash::HashAlgorithm::Sha256,
-        );
+        let update_commitment =
+            multihash::canonicalize_then_double_hash_then_encode(&update1_public_key)?;
 
         let update_payload = DidUpdatePayload {
             update_type: UpdateType::Update,
@@ -686,7 +767,7 @@ mod tests {
         assert_eq!(result.is_ok(), true);
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         // after update, resolve and check if there is the new added service
         let result = did_handler
@@ -706,12 +787,15 @@ mod tests {
         assert_eq!(did_document_services.len(), 1);
         assert_eq!(did_document_services[0].service_endpoint, service_endpoint);
 
-        let patch: Patch = Patch::RemoveServiceEndpoints(vade_sidetree_client::RemoveServices {
+        let patch: Patch = Patch::RemoveServices(vade_sidetree_client::RemoveServices {
             ids: vec!["sds".to_string()],
         });
 
+        let update2_key_pair = secp256k1::KeyPair::random();
+        let mut update2_public_key: JsonWebKey = (&update2_key_pair).into();
+        update2_public_key.d = None;
         let update_commitment =
-            multihash::canonicalize_then_hash_then_encode(&patch, multihash::HashAlgorithm::Sha256);
+            multihash::canonicalize_then_double_hash_then_encode(&update2_public_key)?;
 
         let update_payload = DidUpdatePayload {
             update_type: UpdateType::Update,
@@ -733,7 +817,7 @@ mod tests {
         assert_eq!(result.is_ok(), true);
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         // after update, resolve and check if the service is removed
         let result = did_handler
@@ -753,7 +837,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_update_did_recover() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
@@ -773,7 +858,7 @@ mod tests {
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(30000));
 
         // resolve DID
         let result = did_handler
@@ -804,20 +889,16 @@ mod tests {
         let patch: Patch = Patch::Replace(vade_sidetree_client::ReplaceDocument {
             document: Document {
                 public_keys: vec![update1_key_pair
-                    .to_public_key("doc_key".into(), Some([Purpose::Agreement].to_vec()))],
+                    .to_public_key("doc_key".into(), Some([Purpose::KeyAgreement].to_vec()))],
                 services: None,
             },
         });
 
-        let recovery_commitment = multihash::canonicalize_then_hash_then_encode(
-            &recover1_public_key,
-            multihash::HashAlgorithm::Sha256,
-        );
+        let recovery_commitment =
+            multihash::canonicalize_then_double_hash_then_encode(&recover1_public_key)?;
 
-        let update_commitment = multihash::canonicalize_then_hash_then_encode(
-            &update1_public_key,
-            multihash::HashAlgorithm::Sha256,
-        );
+        let update_commitment =
+            multihash::canonicalize_then_double_hash_then_encode(&update1_public_key)?;
 
         let update_payload = DidUpdatePayload {
             update_type: UpdateType::Recovery,
@@ -837,7 +918,7 @@ mod tests {
             .await;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(30000));
 
         // try to resolve DID after recovery
         let result = did_handler
@@ -853,12 +934,20 @@ mod tests {
         let resolve_result: SidetreeDidDocument = serde_json::from_str(&did_resolve)?;
 
         // check if the replaced key is now in the document
-        assert_eq!(resolve_result.did_document.key_agreement[0].id, "#doc_key");
+        assert_eq!(
+            resolve_result.did_document.verification_method.is_some(),
+            true
+        );
+        assert_eq!(
+            resolve_result.did_document.verification_method.unwrap()[0].id,
+            "#doc_key"
+        );
 
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_update_did_deactivate() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
@@ -911,7 +1000,17 @@ mod tests {
             _ => return Err(Box::from("Unknown Result".to_string())),
         };
 
-        assert_eq!(did_resolve, "{\"status\":\"deactivated\"}");
+        let resolve_result: SidetreeDidDocument = serde_json::from_str(&did_resolve)?;
+
+        // check if the replaced key is now in the document
+        assert_eq!(
+            resolve_result.did_document_metadata.deactivated.is_some(),
+            true
+        );
+        assert_eq!(
+            resolve_result.did_document_metadata.deactivated.unwrap(),
+            true
+        );
 
         Ok(())
     }

--- a/src/vade_sidetree.rs
+++ b/src/vade_sidetree.rs
@@ -28,7 +28,7 @@ use vade_sidetree_client::{
     operations::{RecoverOperationInput, UpdateOperationInput},
 };
 
-const DEFAULT_URL: &str = "https://sidetree.evan.network/1.0/";
+const DEFAULT_URL: &str = "https://sidetree.evan.network/3.0/";
 const EVAN_METHOD: &str = "did:evan";
 const METHOD_REGEX: &str = r#"^(.*):0x(.*)$"#;
 const DID_SIDETREE: &str = "sidetree";
@@ -325,7 +325,7 @@ mod tests {
 
         assert_eq!(result.is_ok(), true);
 
-        let result_value = match result {
+        let result_value = match result? {
             VadePluginResultValue::Success(Some(value)) => value.to_string(),
             _ => return Err(Box::from("Unknown Result".to_string())),
         };

--- a/vade-sidetree-client/src/did.rs
+++ b/vade-sidetree-client/src/did.rs
@@ -6,6 +6,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Document {
     pub public_keys: Vec<PublicKey>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -13,17 +14,19 @@ pub struct Document {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct PublicKey {
     pub id: String,
     #[serde(rename = "type")]
     pub key_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub purpose: Option<Vec<Purpose>>,
+    pub purposes: Option<Vec<Purpose>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub jwk: Option<JsonWebKey>,
+    pub public_key_jwk: Option<JsonWebKey>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct JsonWebKey {
     #[serde(rename = "kty")]
     pub key_type: String,
@@ -36,21 +39,22 @@ pub struct JsonWebKey {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Service {
     pub id: String,
     #[serde(rename = "type")]
     pub service_type: String,
-    pub endpoint: String,
+    pub service_endpoint: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all(serialize = "snake_case", deserialize = "camelCase"))]
+#[serde(rename_all = "camelCase")]
 pub enum Purpose {
-    Auth,
-    Assertion,
-    Invocation,
-    Delegation,
-    Agreement,
+    Authentication,
+    KeyAgreement,
+    AssertionMethod,
+    CapabilityDelegation,
+    CapabilityInvocation,
 }
 
 pub(crate) fn compute_unique_suffix(suffix_data: &SuffixData) -> String {

--- a/vade-sidetree-client/src/lib.rs
+++ b/vade-sidetree-client/src/lib.rs
@@ -3,12 +3,14 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Delta {
     pub patches: Vec<Patch>,
     pub update_commitment: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct SuffixData {
     pub delta_hash: String,
     pub recovery_commitment: String,
@@ -17,12 +19,14 @@ pub struct SuffixData {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct SignedUpdateDataPayload {
     pub delta_hash: String,
     pub update_key: JsonWebKey,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct SignedRecoveryDataPayload {
     pub delta_hash: String,
     pub recovery_key: JsonWebKey,
@@ -30,6 +34,7 @@ pub struct SignedRecoveryDataPayload {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct SignedDeactivateDataPayload {
     pub did_suffix: String,
     pub recovery_key: JsonWebKey,
@@ -41,6 +46,7 @@ pub struct RemovePublicKeys {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AddPublicKeys {
     pub public_keys: Vec<PublicKey>,
 }
@@ -51,8 +57,9 @@ pub struct RemoveServices {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AddServices {
-    pub service_endpoints: Vec<Service>,
+    pub services: Vec<Service>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -66,8 +73,8 @@ pub struct ReplaceDocument {
 pub enum Patch {
     AddPublicKeys(AddPublicKeys),
     RemovePublicKeys(RemovePublicKeys),
-    AddServiceEndpoints(AddServices),
-    RemoveServiceEndpoints(RemoveServices),
+    AddServices(AddServices),
+    RemoveServices(RemoveServices),
     Replace(ReplaceDocument),
     IetfJsonPatch,
 }

--- a/vade-sidetree-client/src/secp256k1.rs
+++ b/vade-sidetree-client/src/secp256k1.rs
@@ -27,15 +27,15 @@ impl KeyPair {
         )
     }
 
-    pub fn to_public_key(&self, id: String, purpose: Option<Vec<Purpose>>) -> crate::PublicKey {
+    pub fn to_public_key(&self, id: String, purposes: Option<Vec<Purpose>>) -> crate::PublicKey {
         let mut jwk: JsonWebKey = self.into();
         jwk.d = None;
 
         crate::PublicKey {
             id,
             key_type: "EcdsaSecp256k1VerificationKey2019".to_string(),
-            purpose,
-            jwk: Some(jwk),
+            purposes,
+            public_key_jwk: Some(jwk),
         }
     }
 


### PR DESCRIPTION
This PR adjusts the implementation of vade-sidetree (and also the sidetree library) to match the protocol version 1.0

- Adjust Struct naming alignments
- Adjust the hashing mechanismns to use the updated spec
- Adjust the operation names 