### PR TITLE
Sdk - Align implementation to spec 1.0 of sidetree

### DIFF
--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -14,6 +14,7 @@ pub enum UpdateType {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct OperationRequestGenerated {
     pub r#type: String,
     pub suffix_data: SuffixData,
@@ -21,6 +22,7 @@ pub struct OperationRequestGenerated {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct DIDCreateResult {
     pub operation_request: OperationRequestGenerated,
     pub did_suffix: String,
@@ -29,6 +31,7 @@ pub struct DIDCreateResult {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct SignedDataPayload {
     pub update_key: JsonWebKey,
     pub delta_hash: String,
@@ -57,7 +60,7 @@ pub struct DidDocument {
     pub id: String,
     #[serde(rename = "@context")]
     pub context: Value,
-    pub key_agreement: Vec<KeyAgreement>,
+    pub verification_method: Option<Vec<KeyAgreement>>,
     pub service: Option<Vec<Service>>,
 }
 
@@ -74,8 +77,16 @@ pub struct KeyAgreement {
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DidDocumentMetadata {
-    pub recovery_commitment: String,
-    pub update_commitment: String,
+    pub method: MethodMetadata,
+    pub deactivated: Option<bool>,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MethodMetadata {
+    pub published: bool,
+    pub recovery_commitment: Option<String>,
+    pub update_commitment: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
@@ -88,6 +99,7 @@ pub struct Service {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct DidUpdatePayload {
     pub update_type: UpdateType,
     pub update_key: Option<JsonWebKey>,
@@ -98,6 +110,7 @@ pub struct DidUpdatePayload {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct DidCreateResponse {
     pub update_key: JsonWebKey,
     pub recovery_key: JsonWebKey,

--- a/src/in3_request_list.rs
+++ b/src/in3_request_list.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::error::Error;
 #[cfg(feature = "sdk")]
 use std::ffi::{CStr, CString};
@@ -16,7 +15,7 @@ pub type ResolveHttpRequest = extern "C" fn(
 pub fn send_request(
     url: String,
     method: String,
-    payload: Option<HashMap<&str, &str>>,
+    payload: Option<String>,
     request_pointer: *const c_void,
     resolve_http_request: ResolveHttpRequest,
 ) -> Result<String, Box<dyn Error>> {
@@ -29,8 +28,7 @@ pub fn send_request(
     let path = CString::new("")?;
     let path = path.as_ptr();
 
-    let payload = serde_json::to_string(&payload)?;
-    let payload = CString::new(payload)?;
+    let payload = CString::new(payload.ok_or("")?)?;
     let payload = payload.as_ptr();
 
     let mut res: *mut c_char = std::ptr::null_mut();

--- a/src/vade_sidetree.rs
+++ b/src/vade_sidetree.rs
@@ -20,23 +20,18 @@ use crate::datatypes::*;
 #[cfg(feature = "sdk")]
 use crate::in3_request_list::{send_request, ResolveHttpRequest};
 use async_trait::async_trait;
-use base64::encode_config;
 use regex::Regex;
 #[cfg(not(feature = "sdk"))]
 use reqwest::Client;
-use std::collections::HashMap;
-use std::error::Error;
-
 use serde::{Deserialize, Serialize};
+use std::error::Error;
 #[cfg(feature = "sdk")]
 use std::os::raw::c_void;
 use vade::{VadePlugin, VadePluginResultValue};
 use vade_sidetree_client::{
     did::JsonWebKey,
-    operations::{
-        self, DeactivateOperationInput, Operation, OperationInput, RecoverOperationInput,
-        UpdateOperationInput,
-    },
+    operations::{self, DeactivateOperationInput, OperationInput},
+    operations::{RecoverOperationInput, UpdateOperationInput},
 };
 
 const DEFAULT_URL: &str = "https://sidetree.evan.network/1.0/";
@@ -136,18 +131,6 @@ impl VadePlugin for VadeSidetree {
         let mut api_url = self.config.sidetree_rest_api_url.clone();
         api_url.push_str("operations");
         let create_result: DIDCreateResult = serde_json::from_str(&json)?;
-        let suffix_data_base64 = &encode_config(
-            serde_json::to_string(&create_result.operation_request.suffix_data)?,
-            base64::STANDARD_NO_PAD,
-        );
-        let delta_base64 = &encode_config(
-            serde_json::to_string(&create_result.operation_request.delta)?,
-            base64::STANDARD_NO_PAD,
-        );
-        let mut map = HashMap::new();
-        map.insert("type", "create");
-        map.insert("suffix_data", suffix_data_base64);
-        map.insert("delta", delta_base64);
 
         #[cfg(feature = "sdk")]
         let request_pointer = self.config.request_id.clone();
@@ -157,18 +140,23 @@ impl VadePlugin for VadeSidetree {
 
         cfg_if::cfg_if! {
             if #[cfg(feature = "sdk")]{
-                    let res = send_request(api_url, "POST".to_string(), Some(map), request_pointer, resolve_http_request)?;
+                    let res = send_request(api_url, "POST".to_string(), Some(serde_json::to_string(&create_output.operation_request)?), request_pointer, resolve_http_request)?;
                     return Ok(VadePluginResultValue::Success(Some(res.to_string())));
             } else {
-                let client = Client::new();
-                let res = client.post(api_url).json(&map).send().await?.text().await?;
+                let client = reqwest::Client::new();
+                let res = client
+                    .post(api_url)
+                    .json(&create_result.operation_request)
+                    .send()
+                    .await?
+                    .text()
+                    .await?;
 
                 let response = DidCreateResponse {
                     update_key: create_result.update_key,
                     recovery_key: create_result.recovery_key,
                     did: serde_json::from_str(&res)?,
                 };
-
                 Ok(VadePluginResultValue::Success(Some(serde_json::to_string(&response)?)))
             }
         }
@@ -196,7 +184,6 @@ impl VadePlugin for VadeSidetree {
 
         let mut operation_type: String = String::new();
         let mut api_url = self.config.sidetree_rest_api_url.clone();
-        let mut map: HashMap<&str, &str> = HashMap::new();
         #[cfg(not(feature = "sdk"))]
         let client = Client::new();
 
@@ -267,43 +254,14 @@ impl VadePlugin for VadeSidetree {
             Err(err) => return Err(Box::from(format!("{}", err))),
         };
 
-        let res = match update_output.operation_request {
-            Operation::Update(did, delta, signed) | Operation::Recover(did, delta, signed) => {
-                let mut delta_base64 = String::new();
-                delta_base64.push_str(&encode_config(
-                    serde_json::to_string(&delta)?,
-                    base64::STANDARD_NO_PAD,
-                ));
-
-                map.insert("type", &operation_type);
-                map.insert("signed_data", &signed);
-                map.insert("did_suffix", &did);
-                map.insert("delta", &delta_base64);
-
-                cfg_if::cfg_if! {
-                    if #[cfg(feature = "sdk")]{
-                        send_request(api_url, "POST".to_string(), Some(map), request_pointer, resolve_http_request)?
-                    } else {
-                        client.post(api_url).json(&map).send().await?.text().await?
-                    }
-                }
+        let res;
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "sdk")]{
+                res = send_request(api_url, "POST".to_string(), Some(serde_json::to_string(&update_output.operation_request)?), request_pointer, resolve_http_request)?
+            } else {
+                res = client.post(api_url).json(&update_output.operation_request).send().await?.text().await?
             }
-
-            Operation::Deactivate(did, signed) => {
-                map.insert("type", &operation_type);
-                map.insert("signed_data", &signed);
-                map.insert("did_suffix", &did);
-
-                cfg_if::cfg_if! {
-                    if #[cfg(feature = "sdk")]{
-                        send_request(api_url, "POST".to_string(), Some(map), request_pointer, resolve_http_request)?
-                    } else {
-                        client.post(api_url).json(&map).send().await?.text().await?
-                    }
-                }
-            }
-            _ => return Err(Box::from("Invalid operation")),
-        };
+        }
 
         Ok(VadePluginResultValue::Success(Some(res)))
     }
@@ -369,7 +327,8 @@ mod tests {
         });
     }
 
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_create_did() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
@@ -383,7 +342,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_create_did_with_predefined_keys() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
@@ -431,7 +391,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_resolve_did() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
@@ -450,7 +411,7 @@ mod tests {
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         let result = did_handler
             .did_resolve(&create_response.did.did_document.id)
@@ -470,7 +431,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_update_did_add_public_keys() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
@@ -495,13 +457,14 @@ mod tests {
         // then add a new public key to the DID
         let key_pair = secp256k1::KeyPair::random();
         let update_key =
-            key_pair.to_public_key("update_key".into(), Some([Purpose::Agreement].to_vec()));
+            key_pair.to_public_key("update_key".into(), Some([Purpose::KeyAgreement].to_vec()));
 
         let patch: Patch = Patch::AddPublicKeys(vade_sidetree_client::AddPublicKeys {
             public_keys: vec![update_key.clone()],
         });
 
-        let update_commitment = multihash::canonicalize_then_double_hash_then_encode(&update_key)?;
+        let update_commitment =
+            multihash::canonicalize_then_double_hash_then_encode(&update_key.public_key_jwk)?;
 
         let update_payload = DidUpdatePayload {
             update_type: UpdateType::Update,
@@ -520,7 +483,7 @@ mod tests {
             )
             .await;
 
-        let _respone = match result? {
+        let _response = match result? {
             VadePluginResultValue::Success(Some(value)) => value.to_string(),
             _ => return Err(Box::from("Unknown Result".to_string())),
         };
@@ -539,37 +502,56 @@ mod tests {
         };
 
         let resolve_result: SidetreeDidDocument = serde_json::from_str(&did_resolve)?;
-        assert_eq!(resolve_result.did_document.key_agreement.len(), 1);
+        assert_eq!(
+            resolve_result.did_document.verification_method.is_some(),
+            true
+        );
+        assert_eq!(
+            resolve_result
+                .did_document
+                .verification_method
+                .unwrap()
+                .len(),
+            1
+        );
 
         Ok(())
     }
 
-    #[ignore]
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_update_did_remove_public_keys() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
+        let mut did_handler = VadeSidetree::new(std::env::var("SIDETREE_API_URL").ok());
 
-        let create_operation = operations::create(None);
-        let create_output = match create_operation {
-            Ok(value) => value,
-            Err(err) => return Err(Box::from(format!(" {}", err))),
+        // first create a new DID on sidetree
+        let result = did_handler
+            .did_create("did:evan", "{\"type\":\"sidetree\"}", "{}")
+            .await;
+        assert!(result.is_ok());
+
+        let response = match result? {
+            VadePluginResultValue::Success(Some(value)) => value.to_string(),
+            _ => return Err(Box::from("Unknown Result".to_string())),
         };
-        let json = serde_json::to_string(&create_output)?;
-        let create_response: DIDCreateResult = serde_json::from_str(&json)?;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
+        let create_response: DidCreateResponse = serde_json::from_str(&response)?;
+
+        // then add a new public key to the DID
         let key_pair = secp256k1::KeyPair::random();
         let update_key =
-            key_pair.to_public_key("update_key".into(), Some([Purpose::Agreement].to_vec()));
+            key_pair.to_public_key("update_key".into(), Some([Purpose::KeyAgreement].to_vec()));
 
-        let patch: Patch = Patch::RemovePublicKeys(vade_sidetree_client::RemovePublicKeys {
-            ids: vec!["update_key".to_string()],
+        let patch: Patch = Patch::AddPublicKeys(vade_sidetree_client::AddPublicKeys {
+            public_keys: vec![update_key.clone()],
         });
 
-        let update_commitment = multihash::canonicalize_then_double_hash_then_encode(&update_key)?;
+        let update_commitment =
+            multihash::canonicalize_then_double_hash_then_encode(&update_key.public_key_jwk)?;
 
         let update_payload = DidUpdatePayload {
             update_type: UpdateType::Update,
@@ -580,13 +562,72 @@ mod tests {
             recovery_key: None,
         };
 
-        let mut did_handler = VadeSidetree::new(std::env::var("SIDETREE_API_URL").ok());
         let result = did_handler
             .did_update(
-                &format!(
-                    "did:evan:{}",
-                    "EiC5_bIqTpMDGHBra-XnjoVV1r4mZwBt9pYNx8VaSaEZtQ"
-                ),
+                &create_response.did.did_document.id,
+                &"{\"type\":\"sidetree\"}",
+                &serde_json::to_string(&update_payload)?,
+            )
+            .await;
+
+        let _response = match result? {
+            VadePluginResultValue::Success(Some(value)) => value.to_string(),
+            _ => return Err(Box::from("Unknown Result".to_string())),
+        };
+
+        // Sleep is required to let the create or update operation take effect
+        thread::sleep(Duration::from_millis(40000));
+
+        // after update, resolve and check if there are 2 public keys in the DID document
+        let result = did_handler
+            .did_resolve(&create_response.did.did_document.id)
+            .await;
+
+        let did_resolve = match result? {
+            VadePluginResultValue::Success(Some(value)) => value.to_string(),
+            _ => return Err(Box::from("Unknown Result".to_string())),
+        };
+
+        let resolve_result: SidetreeDidDocument = serde_json::from_str(&did_resolve)?;
+        assert_eq!(
+            resolve_result.did_document.verification_method.is_some(),
+            true
+        );
+        assert_eq!(
+            resolve_result
+                .did_document
+                .verification_method
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // then remove the public key from the DID again
+        let new_key_pair = secp256k1::KeyPair::random();
+        let new_update_key = new_key_pair.to_public_key(
+            "new_update_key".into(),
+            Some([Purpose::KeyAgreement].to_vec()),
+        );
+
+        let patch: Patch = Patch::RemovePublicKeys(vade_sidetree_client::RemovePublicKeys {
+            ids: vec!["update_key".to_string()],
+        });
+
+        let update_commitment =
+            multihash::canonicalize_then_double_hash_then_encode(&new_update_key)?;
+
+        let update_payload = DidUpdatePayload {
+            update_type: UpdateType::Update,
+            update_key: Some(JsonWebKey::from(&key_pair)),
+            update_commitment: Some(update_commitment),
+            patches: Some(vec![patch]),
+            recovery_commitment: None,
+            recovery_key: None,
+        };
+
+        let result = did_handler
+            .did_update(
+                &format!("did:evan:{}", &create_response.did.did_document.id),
                 &"{\"type\":\"sidetree\"}",
                 &serde_json::to_string(&update_payload)?,
             )
@@ -598,10 +639,29 @@ mod tests {
             _ => return Err(Box::from("Unknown Result".to_string())),
         };
 
+        // Sleep is required to let the create or update operation take effect
+        thread::sleep(Duration::from_millis(40000));
+
+        // after update, resolve and check if there are 2 public keys in the DID document
+        let result = did_handler
+            .did_resolve(&create_response.did.did_document.id)
+            .await;
+
+        let did_resolve = match result? {
+            VadePluginResultValue::Success(Some(value)) => value.to_string(),
+            _ => return Err(Box::from("Unknown Result".to_string())),
+        };
+
+        let resolve_result: SidetreeDidDocument = serde_json::from_str(&did_resolve)?;
+        assert_eq!(
+            resolve_result.did_document.verification_method.is_some(),
+            false
+        );
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_update_did_add_service_endpoints() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
@@ -628,17 +688,20 @@ mod tests {
         let service = Service {
             id: "sds".to_string(),
             service_type: "SecureDataStrore".to_string(),
-            endpoint: service_endpoint.clone(),
+            service_endpoint: service_endpoint.clone(),
         };
 
-        let patch: Patch = Patch::AddServiceEndpoints(vade_sidetree_client::AddServices {
-            service_endpoints: vec![service],
+        let patch: Patch = Patch::AddServices(vade_sidetree_client::AddServices {
+            services: vec![service],
         });
 
-        let update_commitment = multihash::canonicalize_then_hash_then_encode(
-            &create_response.update_key,
-            multihash::HashAlgorithm::Sha256,
-        );
+        // then add a new public key to the DID
+        let key_pair = secp256k1::KeyPair::random();
+        let update_key =
+            key_pair.to_public_key("update_key".into(), Some([Purpose::KeyAgreement].to_vec()));
+
+        let update_commitment =
+            multihash::canonicalize_then_double_hash_then_encode(&update_key.public_key_jwk)?;
 
         let update_payload = DidUpdatePayload {
             update_type: UpdateType::Update,
@@ -657,10 +720,13 @@ mod tests {
             )
             .await;
 
-        assert_eq!(result.is_ok(), true);
+        let _response = match result? {
+            VadePluginResultValue::Success(Some(value)) => value.to_string(),
+            _ => return Err(Box::from("Unknown Result".to_string())),
+        };
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         // after update, resolve and check if there is the new added service
         let result = did_handler
@@ -683,7 +749,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_update_did_remove_services() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
@@ -710,21 +777,19 @@ mod tests {
         let service = Service {
             id: "sds".to_string(),
             service_type: "SecureDataStrore".to_string(),
-            endpoint: service_endpoint.clone(),
+            service_endpoint: service_endpoint.clone(),
         };
 
-        let patch: Patch = Patch::AddServiceEndpoints(vade_sidetree_client::AddServices {
-            service_endpoints: vec![service],
+        let patch: Patch = Patch::AddServices(vade_sidetree_client::AddServices {
+            services: vec![service],
         });
 
         let update1_key_pair = secp256k1::KeyPair::random();
         let mut update1_public_key: JsonWebKey = (&update1_key_pair).into();
         update1_public_key.d = None;
 
-        let update_commitment = multihash::canonicalize_then_hash_then_encode(
-            &update1_public_key,
-            multihash::HashAlgorithm::Sha256,
-        );
+        let update_commitment =
+            multihash::canonicalize_then_double_hash_then_encode(&update1_public_key)?;
 
         let update_payload = DidUpdatePayload {
             update_type: UpdateType::Update,
@@ -746,7 +811,7 @@ mod tests {
         assert_eq!(result.is_ok(), true);
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         // after update, resolve and check if there is the new added service
         let result = did_handler
@@ -766,12 +831,15 @@ mod tests {
         assert_eq!(did_document_services.len(), 1);
         assert_eq!(did_document_services[0].service_endpoint, service_endpoint);
 
-        let patch: Patch = Patch::RemoveServiceEndpoints(vade_sidetree_client::RemoveServices {
+        let patch: Patch = Patch::RemoveServices(vade_sidetree_client::RemoveServices {
             ids: vec!["sds".to_string()],
         });
 
+        let update2_key_pair = secp256k1::KeyPair::random();
+        let mut update2_public_key: JsonWebKey = (&update2_key_pair).into();
+        update2_public_key.d = None;
         let update_commitment =
-            multihash::canonicalize_then_hash_then_encode(&patch, multihash::HashAlgorithm::Sha256);
+            multihash::canonicalize_then_double_hash_then_encode(&update2_public_key)?;
 
         let update_payload = DidUpdatePayload {
             update_type: UpdateType::Update,
@@ -793,7 +861,7 @@ mod tests {
         assert_eq!(result.is_ok(), true);
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         // after update, resolve and check if the service is removed
         let result = did_handler
@@ -813,7 +881,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_update_did_recover() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
@@ -833,7 +902,7 @@ mod tests {
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(30000));
 
         // resolve DID
         let result = did_handler
@@ -864,20 +933,16 @@ mod tests {
         let patch: Patch = Patch::Replace(vade_sidetree_client::ReplaceDocument {
             document: Document {
                 public_keys: vec![update1_key_pair
-                    .to_public_key("doc_key".into(), Some([Purpose::Agreement].to_vec()))],
+                    .to_public_key("doc_key".into(), Some([Purpose::KeyAgreement].to_vec()))],
                 services: None,
             },
         });
 
-        let recovery_commitment = multihash::canonicalize_then_hash_then_encode(
-            &recover1_public_key,
-            multihash::HashAlgorithm::Sha256,
-        );
+        let recovery_commitment =
+            multihash::canonicalize_then_double_hash_then_encode(&recover1_public_key)?;
 
-        let update_commitment = multihash::canonicalize_then_hash_then_encode(
-            &update1_public_key,
-            multihash::HashAlgorithm::Sha256,
-        );
+        let update_commitment =
+            multihash::canonicalize_then_double_hash_then_encode(&update1_public_key)?;
 
         let update_payload = DidUpdatePayload {
             update_type: UpdateType::Recovery,
@@ -897,7 +962,7 @@ mod tests {
             .await;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(30000));
 
         // try to resolve DID after recovery
         let result = did_handler
@@ -913,12 +978,20 @@ mod tests {
         let resolve_result: SidetreeDidDocument = serde_json::from_str(&did_resolve)?;
 
         // check if the replaced key is now in the document
-        assert_eq!(resolve_result.did_document.key_agreement[0].id, "#doc_key");
+        assert_eq!(
+            resolve_result.did_document.verification_method.is_some(),
+            true
+        );
+        assert_eq!(
+            resolve_result.did_document.verification_method.unwrap()[0].id,
+            "#doc_key"
+        );
 
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::main]
+    #[test]
     #[serial]
     async fn can_update_did_deactivate() -> Result<(), Box<dyn std::error::Error>> {
         enable_logging();
@@ -971,7 +1044,17 @@ mod tests {
             _ => return Err(Box::from("Unknown Result".to_string())),
         };
 
-        assert_eq!(did_resolve, "{\"status\":\"deactivated\"}");
+        let resolve_result: SidetreeDidDocument = serde_json::from_str(&did_resolve)?;
+
+        // check if the replaced key is now in the document
+        assert_eq!(
+            resolve_result.did_document_metadata.deactivated.is_some(),
+            true
+        );
+        assert_eq!(
+            resolve_result.did_document_metadata.deactivated.unwrap(),
+            true
+        );
 
         Ok(())
     }

--- a/src/vade_sidetree.rs
+++ b/src/vade_sidetree.rs
@@ -34,7 +34,7 @@ use vade_sidetree_client::{
     operations::{RecoverOperationInput, UpdateOperationInput},
 };
 
-const DEFAULT_URL: &str = "https://sidetree.evan.network/1.0/";
+const DEFAULT_URL: &str = "https://sidetree.evan.network/3.0/";
 const EVAN_METHOD: &str = "did:evan";
 const METHOD_REGEX: &str = r#"^(.*):0x(.*)$"#;
 const DID_SIDETREE: &str = "sidetree";

--- a/src/vade_sidetree.rs
+++ b/src/vade_sidetree.rs
@@ -452,7 +452,7 @@ mod tests {
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         // then add a new public key to the DID
         let key_pair = secp256k1::KeyPair::random();
@@ -489,7 +489,7 @@ mod tests {
         };
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         // after update, resolve and check if there are 2 public keys in the DID document
         let result = did_handler
@@ -681,7 +681,7 @@ mod tests {
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         let service_endpoint = "https://w3id.org/did-resolution/v1".to_string();
 
@@ -770,7 +770,7 @@ mod tests {
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         let service_endpoint = "https://w3id.org/did-resolution/v1".to_string();
 
@@ -902,7 +902,7 @@ mod tests {
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(30000));
+        thread::sleep(Duration::from_millis(40000));
 
         // resolve DID
         let result = did_handler
@@ -962,7 +962,7 @@ mod tests {
             .await;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(30000));
+        thread::sleep(Duration::from_millis(40000));
 
         // try to resolve DID after recovery
         let result = did_handler
@@ -1011,7 +1011,7 @@ mod tests {
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
 
         let update_payload = DidUpdatePayload {
             update_type: UpdateType::Deactivate,
@@ -1033,7 +1033,7 @@ mod tests {
         assert_eq!(result.is_ok(), true);
 
         // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(20000));
+        thread::sleep(Duration::from_millis(40000));
         // after update, resolve and check if the DID is deactivated
         let result = did_handler
             .did_resolve(&create_response.did.did_document.id)

--- a/vade-sidetree-client/src/did.rs
+++ b/vade-sidetree-client/src/did.rs
@@ -6,6 +6,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Document {
     pub public_keys: Vec<PublicKey>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -13,17 +14,19 @@ pub struct Document {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct PublicKey {
     pub id: String,
     #[serde(rename = "type")]
     pub key_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub purpose: Option<Vec<Purpose>>,
+    pub purposes: Option<Vec<Purpose>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub jwk: Option<JsonWebKey>,
+    pub public_key_jwk: Option<JsonWebKey>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct JsonWebKey {
     #[serde(rename = "kty")]
     pub key_type: String,
@@ -36,21 +39,22 @@ pub struct JsonWebKey {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Service {
     pub id: String,
     #[serde(rename = "type")]
     pub service_type: String,
-    pub endpoint: String,
+    pub service_endpoint: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all(serialize = "snake_case", deserialize = "camelCase"))]
+#[serde(rename_all = "camelCase")]
 pub enum Purpose {
-    Auth,
-    Assertion,
-    Invocation,
-    Delegation,
-    Agreement,
+    Authentication,
+    KeyAgreement,
+    AssertionMethod,
+    CapabilityDelegation,
+    CapabilityInvocation,
 }
 
 pub(crate) fn compute_unique_suffix(suffix_data: &SuffixData) -> String {

--- a/vade-sidetree-client/src/lib.rs
+++ b/vade-sidetree-client/src/lib.rs
@@ -3,12 +3,14 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Delta {
     pub patches: Vec<Patch>,
     pub update_commitment: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct SuffixData {
     pub delta_hash: String,
     pub recovery_commitment: String,
@@ -17,12 +19,14 @@ pub struct SuffixData {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct SignedUpdateDataPayload {
     pub delta_hash: String,
     pub update_key: JsonWebKey,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct SignedRecoveryDataPayload {
     pub delta_hash: String,
     pub recovery_key: JsonWebKey,
@@ -30,6 +34,7 @@ pub struct SignedRecoveryDataPayload {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct SignedDeactivateDataPayload {
     pub did_suffix: String,
     pub recovery_key: JsonWebKey,
@@ -41,6 +46,7 @@ pub struct RemovePublicKeys {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AddPublicKeys {
     pub public_keys: Vec<PublicKey>,
 }
@@ -51,8 +57,9 @@ pub struct RemoveServices {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AddServices {
-    pub service_endpoints: Vec<Service>,
+    pub services: Vec<Service>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -66,8 +73,8 @@ pub struct ReplaceDocument {
 pub enum Patch {
     AddPublicKeys(AddPublicKeys),
     RemovePublicKeys(RemovePublicKeys),
-    AddServiceEndpoints(AddServices),
-    RemoveServiceEndpoints(RemoveServices),
+    AddServices(AddServices),
+    RemoveServices(RemoveServices),
     Replace(ReplaceDocument),
     IetfJsonPatch,
 }

--- a/vade-sidetree-client/src/secp256k1.rs
+++ b/vade-sidetree-client/src/secp256k1.rs
@@ -27,15 +27,15 @@ impl KeyPair {
         )
     }
 
-    pub fn to_public_key(&self, id: String, purpose: Option<Vec<Purpose>>) -> crate::PublicKey {
+    pub fn to_public_key(&self, id: String, purposes: Option<Vec<Purpose>>) -> crate::PublicKey {
         let mut jwk: JsonWebKey = self.into();
         jwk.d = None;
 
         crate::PublicKey {
             id,
             key_type: "EcdsaSecp256k1VerificationKey2019".to_string(),
-            purpose,
-            jwk: Some(jwk),
+            purposes,
+            public_key_jwk: Some(jwk),
         }
     }
 


### PR DESCRIPTION
This PR adjusts the implementation of vade-sidetree (and also the sidetree library) to match the protocol version 1.0

Adjust Struct naming alignments
Adjust the hashing mechanismns to use the updated spec
Adjust the operation names