### PR TITLE
Add waitfor check to did creation/update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
  "value-bag",
@@ -1862,6 +1862,7 @@ dependencies = [
  "async-trait",
  "base64",
  "env_logger",
+ "log",
  "regex",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-channel"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
+dependencies = [
+ "async-lock",
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "log",
+ "parking",
+ "polling",
+ "slab",
+ "socket2",
+ "waker-fn",
+ "windows-sys",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
+dependencies = [
+ "event-listener",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
+
+[[package]]
 name = "async-trait"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +135,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -138,6 +246,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
+name = "blocking"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c67b173a56acffd6d2326fb7ab938ba0b00a71480e14902b2591c87bc5741e8"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +302,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +342,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +374,16 @@ checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.4",
  "subtle 2.4.1",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -277,10 +427,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "fnv"
@@ -360,6 +525,21 @@ name = "futures-io"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+
+[[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-macro"
@@ -447,6 +627,18 @@ dependencies = [
  "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98c4a8d6391675c6b2ee1a6c8d06e8e2d03605c44cec1270675985a4c2a5500b"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
  "wasm-bindgen",
 ]
 
@@ -658,6 +850,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+ "value-bag",
 ]
 
 [[package]]
@@ -863,6 +1065,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +1118,20 @@ name = "pkg-config"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
+
+[[package]]
+name = "polling"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22122d5ec4f9fe1b3916419b76be1e80bcb93f618d071d2edf841b137b2a2bd6"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "windows-sys",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1636,6 +1858,7 @@ dependencies = [
 name = "vade-sidetree"
 version = "0.0.3"
 dependencies = [
+ "async-std",
  "async-trait",
  "base64",
  "env_logger",
@@ -1666,6 +1889,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "value-bag"
+version = "1.0.0-alpha.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
+dependencies = [
+ "ctor",
+ "version_check",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1676,6 +1909,12 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "want"
@@ -1795,6 +2034,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,6 +2072,63 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ async-std = "1.12.0"
 async-trait = "0.1.31"
 base64 = "0.13.0"
 env_logger = "0.7.1"
+log = "0.4.17" # pinned version for dependency of `async-std`
 regex = { version = "1.3.7" }
 reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-std = "1.12.0"
 async-trait = "0.1.31"
 base64 = "0.13.0"
 env_logger = "0.7.1"

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -5,6 +5,7 @@
 ### Features
 
 - add support for passing keys to DID creation
+- add new flag `waitForCompletion` to the creation and update process
 
 ### Fixes
 

--- a/src/vade_sidetree.rs
+++ b/src/vade_sidetree.rs
@@ -18,9 +18,10 @@ extern crate vade;
 
 use crate::datatypes::*;
 use async_trait::async_trait;
+use core::time;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::error::Error;
+use std::{error::Error, thread};
 use vade::{VadePlugin, VadePluginResultValue};
 use vade_sidetree_client::{
     did::JsonWebKey,
@@ -57,6 +58,15 @@ pub struct CreateDidOptions {
     pub r#type: String,
     pub update_key: Option<JsonWebKey>,
     pub recovery_key: Option<JsonWebKey>,
+    pub wait_for_completion: Option<bool>,
+}
+
+/// Options for DID update.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateDidOptions {
+    pub r#type: String,
+    pub wait_for_completion: Option<bool>,
 }
 
 /// Sidetree Rest API url
@@ -132,6 +142,30 @@ impl VadePlugin for VadeSidetree {
             did: serde_json::from_str(&res)?,
         };
 
+        if options.wait_for_completion == Some(true) {
+            let mut update_found = false;
+            let mut timeout_counter = 0;
+            while !update_found {
+                let res = resolve_sidetree_did(
+                    self.config.sidetree_rest_api_url.clone(),
+                    &response.did.did_document.id,
+                )
+                .await?;
+                dbg!(&res);
+                if res != "Not Found" {
+                    update_found = true;
+                } else {
+                    thread::sleep(time::Duration::from_millis(1000));
+                    timeout_counter += 1;
+                    if timeout_counter == 60 {
+                        return Ok(VadePluginResultValue::Success(Some(
+                            "Error waiting for DID create".to_string(),
+                        )));
+                    }
+                }
+            }
+        }
+
         Ok(VadePluginResultValue::Success(Some(serde_json::to_string(
             &response,
         )?)))
@@ -157,29 +191,35 @@ impl VadePlugin for VadeSidetree {
             return Ok(VadePluginResultValue::Ignored);
         }
 
+        let options: UpdateDidOptions = serde_json::from_str(options)?;
         let mut operation_type: String = String::new();
         let mut api_url = self.config.sidetree_rest_api_url.clone();
         let client = reqwest::Client::new();
-
+        let mut check_commitment: String = String::new();
         api_url.push_str("operations");
 
         let update_payload: DidUpdatePayload = serde_json::from_str(payload)?;
         let update_operation = match update_payload.update_type {
             UpdateType::Update | UpdateType::Recovery => {
                 if update_payload.update_type == UpdateType::Update {
+                    check_commitment = update_payload
+                        .update_commitment
+                        .ok_or("update_commitment not valid")?
+                        .clone()
+                        .to_string();
                     let operation = UpdateOperationInput::new()
                         .with_did_suffix(did.split(":").last().ok_or("did not valid")?.to_string())
                         .with_patches(update_payload.patches.ok_or("patches not valid")?)
                         .with_update_key(update_payload.update_key.ok_or("update_key not valid")?)
-                        .with_update_commitment(
-                            update_payload
-                                .update_commitment
-                                .ok_or("update_commitment not valid")?
-                                .to_string(),
-                        );
+                        .with_update_commitment(check_commitment.clone());
                     operation_type.push_str("update");
                     operations::update(operation)
                 } else {
+                    check_commitment = update_payload
+                        .update_commitment
+                        .ok_or("update_commitment not valid")?
+                        .clone()
+                        .to_string();
                     let operation = RecoverOperationInput::new()
                         .with_did_suffix(did.split(":").last().ok_or("did not valid")?.to_string())
                         .with_patches(update_payload.patches.ok_or("patches not valid")?)
@@ -194,12 +234,7 @@ impl VadePlugin for VadeSidetree {
                                 .ok_or("recovery_commitment not valid")?
                                 .to_string(),
                         )
-                        .with_update_commitment(
-                            update_payload
-                                .update_commitment
-                                .ok_or("update_commitment not valid")?
-                                .to_string(),
-                        );
+                        .with_update_commitment(check_commitment.clone());
                     operation_type.push_str("recover");
                     operations::recover(operation)
                 }
@@ -229,6 +264,44 @@ impl VadePlugin for VadeSidetree {
             .text()
             .await?;
 
+        if options.wait_for_completion == Some(true) {
+            let mut update_found = false;
+            let mut timeout_counter = 0;
+            while !update_found {
+                let res =
+                    resolve_sidetree_did(self.config.sidetree_rest_api_url.clone(), &did).await?;
+                dbg!(&res);
+                if res != "Not Found" {
+                    let did_document: SidetreeDidDocument = serde_json::from_str(&res)?;
+                    match update_payload.update_type {
+                        UpdateType::Update | UpdateType::Recovery => {
+                            if did_document
+                                .did_document_metadata
+                                .method
+                                .update_commitment
+                                .eq(&Some(check_commitment.clone()))
+                            {
+                                update_found = true;
+                            }
+                        }
+                        UpdateType::Deactivate => {
+                            if did_document.did_document_metadata.deactivated == Some(true) {
+                                update_found = true;
+                            }
+                        }
+                    }
+                }
+                if !update_found {
+                    thread::sleep(time::Duration::from_millis(1000));
+                    timeout_counter += 1;
+                    if timeout_counter == 60 {
+                        return Ok(VadePluginResultValue::Success(Some(
+                            "Error waiting for DID update".to_string(),
+                        )));
+                    }
+                }
+            }
+        }
         Ok(VadePluginResultValue::Success(Some(res)))
     }
 
@@ -251,15 +324,19 @@ impl VadePlugin for VadeSidetree {
             return Ok(VadePluginResultValue::Ignored);
         }
 
-        let mut api_url = self.config.sidetree_rest_api_url.clone();
-        api_url.push_str("identifiers/");
-        api_url.push_str(did_id);
-
-        let client = reqwest::Client::new();
-        let res = client.get(api_url).send().await?.text().await?;
+        let res = resolve_sidetree_did(self.config.sidetree_rest_api_url.clone(), did_id).await?;
 
         Ok(VadePluginResultValue::Success(Some(res)))
     }
+}
+
+async fn resolve_sidetree_did(base_url: String, did: &str) -> Result<String, reqwest::Error> {
+    let mut api_url = base_url;
+    api_url.push_str("identifiers/");
+    api_url.push_str(did);
+
+    let client = reqwest::Client::new();
+    client.get(api_url).send().await?.text().await
 }
 
 #[cfg(test)]
@@ -267,7 +344,6 @@ mod tests {
     use super::*;
     use serial_test::serial;
     use std::sync::Once;
-    use std::{thread, time::Duration};
     use vade_sidetree_client::{
         did::{Document, JsonWebKey, Purpose, Service},
         multihash, secp256k1, Patch,
@@ -288,7 +364,11 @@ mod tests {
         enable_logging();
         let mut did_handler = VadeSidetree::new(std::env::var("SIDETREE_API_URL").ok());
         let result = did_handler
-            .did_create("did:evan", "{\"type\":\"sidetree\"}", "{}")
+            .did_create(
+                "did:evan",
+                "{\"type\":\"sidetree\",\"waitForCompletion\":true}",
+                "",
+            )
             .await;
 
         assert_eq!(result.is_ok(), true);
@@ -318,10 +398,11 @@ mod tests {
               "x": "PICqtwQRifxZspzID9073FJSI4AE77kjxQD2_t2cj6U",
               "y": "489btoCSOyvhgQJXU9qo7n25ttJDleOMDVCkpOvB9Uk",
               "d": "gU5iJcTcsSA0q2Ajy5bnBQIzOUthMty7swtGGcWORDw"
-            }
+            },
+            "waitForCompletion":true
           }"###;
 
-        let result = did_handler.did_create("did:evan", options, "{}").await;
+        let result = did_handler.did_create("did:evan", options, "").await;
 
         assert_eq!(result.is_ok(), true);
 
@@ -354,7 +435,11 @@ mod tests {
 
         // first create a new DID on sidetree
         let result = did_handler
-            .did_create("did:evan", "{\"type\":\"sidetree\"}", "{}")
+            .did_create(
+                "did:evan",
+                "{\"type\":\"sidetree\",\"waitForCompletion\":true}",
+                "{}",
+            )
             .await?;
 
         let response = match result {
@@ -363,9 +448,6 @@ mod tests {
         };
 
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
-
-        // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(40000));
 
         let result = did_handler
             .did_resolve(&create_response.did.did_document.id)
@@ -394,7 +476,11 @@ mod tests {
 
         // first create a new DID on sidetree
         let result = did_handler
-            .did_create("did:evan", "{\"type\":\"sidetree\"}", "{}")
+            .did_create(
+                "did:evan",
+                "{\"type\":\"sidetree\", \"waitForCompletion\":true}",
+                "{}",
+            )
             .await;
         assert!(result.is_ok());
 
@@ -404,9 +490,6 @@ mod tests {
         };
 
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
-
-        // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(40000));
 
         // then add a new public key to the DID
         let key_pair = secp256k1::KeyPair::random();
@@ -432,7 +515,7 @@ mod tests {
         let result = did_handler
             .did_update(
                 &create_response.did.did_document.id,
-                &"{\"type\":\"sidetree\"}",
+                &"{\"type\":\"sidetree\", \"waitForCompletion\":true}",
                 &serde_json::to_string(&update_payload)?,
             )
             .await;
@@ -441,9 +524,6 @@ mod tests {
             VadePluginResultValue::Success(Some(value)) => value.to_string(),
             _ => return Err(Box::from("Unknown Result".to_string())),
         };
-
-        // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(40000));
 
         // after update, resolve and check if there are 2 public keys in the DID document
         let result = did_handler
@@ -481,7 +561,11 @@ mod tests {
 
         // first create a new DID on sidetree
         let result = did_handler
-            .did_create("did:evan", "{\"type\":\"sidetree\"}", "{}")
+            .did_create(
+                "did:evan",
+                "{\"type\":\"sidetree\",\"waitForCompletion\":true}",
+                "{}",
+            )
             .await;
         assert!(result.is_ok());
 
@@ -489,9 +573,6 @@ mod tests {
             VadePluginResultValue::Success(Some(value)) => value.to_string(),
             _ => return Err(Box::from("Unknown Result".to_string())),
         };
-
-        // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(40000));
 
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
 
@@ -519,7 +600,7 @@ mod tests {
         let result = did_handler
             .did_update(
                 &create_response.did.did_document.id,
-                &"{\"type\":\"sidetree\"}",
+                &"{\"type\":\"sidetree\", \"waitForCompletion\":true}",
                 &serde_json::to_string(&update_payload)?,
             )
             .await;
@@ -528,9 +609,6 @@ mod tests {
             VadePluginResultValue::Success(Some(value)) => value.to_string(),
             _ => return Err(Box::from("Unknown Result".to_string())),
         };
-
-        // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(40000));
 
         // after update, resolve and check if there are 2 public keys in the DID document
         let result = did_handler
@@ -582,7 +660,7 @@ mod tests {
         let result = did_handler
             .did_update(
                 &format!("did:evan:{}", &create_response.did.did_document.id),
-                &"{\"type\":\"sidetree\"}",
+                &"{\"type\":\"sidetree\", \"waitForCompletion\":true}",
                 &serde_json::to_string(&update_payload)?,
             )
             .await;
@@ -592,9 +670,6 @@ mod tests {
             VadePluginResultValue::Success(Some(value)) => value.to_string(),
             _ => return Err(Box::from("Unknown Result".to_string())),
         };
-
-        // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(40000));
 
         // after update, resolve and check if there are 2 public keys in the DID document
         let result = did_handler
@@ -623,7 +698,11 @@ mod tests {
         let mut did_handler = VadeSidetree::new(std::env::var("SIDETREE_API_URL").ok());
         // first create a new DID on sidetree
         let result = did_handler
-            .did_create("did:evan", "{\"type\":\"sidetree\"}", "{}")
+            .did_create(
+                "did:evan",
+                "{\"type\":\"sidetree\", \"waitForCompletion\":true}",
+                "{}",
+            )
             .await;
         assert!(result.is_ok());
 
@@ -633,9 +712,6 @@ mod tests {
         };
 
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
-
-        // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(40000));
 
         let service_endpoint = "https://w3id.org/did-resolution/v1".to_string();
 
@@ -669,7 +745,7 @@ mod tests {
         let result = did_handler
             .did_update(
                 &create_response.did.did_document.id,
-                &"{\"type\":\"sidetree\"}",
+                &"{\"type\":\"sidetree\", \"waitForCompletion\":true}",
                 &serde_json::to_string(&update_payload)?,
             )
             .await;
@@ -678,9 +754,6 @@ mod tests {
             VadePluginResultValue::Success(Some(value)) => value.to_string(),
             _ => return Err(Box::from("Unknown Result".to_string())),
         };
-
-        // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(40000));
 
         // after update, resolve and check if there is the new added service
         let result = did_handler
@@ -712,7 +785,11 @@ mod tests {
         let mut did_handler = VadeSidetree::new(std::env::var("SIDETREE_API_URL").ok());
         // first create a new DID on sidetree
         let result = did_handler
-            .did_create("did:evan", "{\"type\":\"sidetree\"}", "{}")
+            .did_create(
+                "did:evan",
+                "{\"type\":\"sidetree\", \"waitForCompletion\":true}",
+                "{}",
+            )
             .await;
         assert!(result.is_ok());
 
@@ -722,9 +799,6 @@ mod tests {
         };
 
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
-
-        // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(40000));
 
         let service_endpoint = "https://w3id.org/did-resolution/v1".to_string();
 
@@ -757,15 +831,12 @@ mod tests {
         let result = did_handler
             .did_update(
                 &create_response.did.did_document.id,
-                &"{\"type\":\"sidetree\"}",
+                &"{\"type\":\"sidetree\", \"waitForCompletion\":true}",
                 &serde_json::to_string(&update_payload)?,
             )
             .await;
 
         assert_eq!(result.is_ok(), true);
-
-        // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(40000));
 
         // after update, resolve and check if there is the new added service
         let result = did_handler
@@ -807,15 +878,12 @@ mod tests {
         let result = did_handler
             .did_update(
                 &create_response.did.did_document.id,
-                &"{\"type\":\"sidetree\"}",
+                &"{\"type\":\"sidetree\", \"waitForCompletion\":true}",
                 &serde_json::to_string(&update_payload)?,
             )
             .await;
 
         assert_eq!(result.is_ok(), true);
-
-        // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(40000));
 
         // after update, resolve and check if the service is removed
         let result = did_handler
@@ -844,7 +912,11 @@ mod tests {
         let mut did_handler = VadeSidetree::new(std::env::var("SIDETREE_API_URL").ok());
         // first create a new DID on sidetree
         let result = did_handler
-            .did_create("did:evan", "{\"type\":\"sidetree\"}", "{}")
+            .did_create(
+                "did:evan",
+                "{\"type\":\"sidetree\", \"waitForCompletion\":true}",
+                "{}",
+            )
             .await;
         assert!(result.is_ok());
 
@@ -854,9 +926,6 @@ mod tests {
         };
 
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
-
-        // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(40000));
 
         // resolve DID
         let result = did_handler
@@ -910,13 +979,10 @@ mod tests {
         let _result = did_handler
             .did_update(
                 &create_response.did.did_document.id,
-                "{\"type\":\"sidetree\"}",
+                "{\"type\":\"sidetree\", \"waitForCompletion\":true}",
                 &serde_json::to_string(&update_payload)?,
             )
             .await;
-
-        // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(40000));
 
         // try to resolve DID after recovery
         let result = did_handler
@@ -953,7 +1019,11 @@ mod tests {
         let mut did_handler = VadeSidetree::new(std::env::var("SIDETREE_API_URL").ok());
         // first create a new DID on sidetree
         let result = did_handler
-            .did_create("did:evan", "{\"type\":\"sidetree\"}", "{}")
+            .did_create(
+                "did:evan",
+                "{\"type\":\"sidetree\", \"waitForCompletion\":true}",
+                "{}",
+            )
             .await;
         assert!(result.is_ok());
 
@@ -963,9 +1033,6 @@ mod tests {
         };
 
         let create_response: DidCreateResponse = serde_json::from_str(&response)?;
-
-        // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(40000));
 
         let update_payload = DidUpdatePayload {
             update_type: UpdateType::Deactivate,
@@ -979,15 +1046,12 @@ mod tests {
         let result = did_handler
             .did_update(
                 &create_response.did.did_document.id,
-                "{\"type\":\"sidetree\"}",
+                "{\"type\":\"sidetree\", \"waitForCompletion\":true}",
                 &serde_json::to_string(&update_payload)?,
             )
             .await;
 
         assert_eq!(result.is_ok(), true);
-
-        // Sleep is required to let the create or update operation take effect
-        thread::sleep(Duration::from_millis(40000));
         // after update, resolve and check if the DID is deactivated
         let result = did_handler
             .did_resolve(&create_response.did.did_document.id)

--- a/src/vade_sidetree.rs
+++ b/src/vade_sidetree.rs
@@ -151,7 +151,6 @@ impl VadePlugin for VadeSidetree {
                     &response.did.did_document.id,
                 )
                 .await?;
-                dbg!(&res);
                 if res != "Not Found" {
                     update_found = true;
                 } else {
@@ -270,7 +269,6 @@ impl VadePlugin for VadeSidetree {
             while !update_found {
                 let res =
                     resolve_sidetree_did(self.config.sidetree_rest_api_url.clone(), &did).await?;
-                dbg!(&res);
                 if res != "Not Found" {
                     let did_document: SidetreeDidDocument = serde_json::from_str(&res)?;
                     match update_payload.update_type {

--- a/src/vade_sidetree.rs
+++ b/src/vade_sidetree.rs
@@ -17,11 +17,12 @@ extern crate regex;
 extern crate vade;
 
 use crate::datatypes::*;
+use async_std::task;
 use async_trait::async_trait;
 use core::time;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::{error::Error, thread};
+use std::error::Error;
 use vade::{VadePlugin, VadePluginResultValue};
 use vade_sidetree_client::{
     did::JsonWebKey,
@@ -154,7 +155,7 @@ impl VadePlugin for VadeSidetree {
                 if res != "Not Found" {
                     update_found = true;
                 } else {
-                    thread::sleep(time::Duration::from_millis(1000));
+                    task::sleep(time::Duration::from_millis(1_000)).await;
                     timeout_counter += 1;
                     if timeout_counter == 60 {
                         return Ok(VadePluginResultValue::Success(Some(
@@ -290,7 +291,7 @@ impl VadePlugin for VadeSidetree {
                     }
                 }
                 if !update_found {
-                    thread::sleep(time::Duration::from_millis(1000));
+                    task::sleep(time::Duration::from_millis(1_000)).await;
                     timeout_counter += 1;
                     if timeout_counter == 60 {
                         return Ok(VadePluginResultValue::Success(Some(


### PR DESCRIPTION
This PR adds a new flag into the `options` parameter for VADE sidetree to block the call until the process has been finished. This applies to the `create`, `update`, `deactivate` and `recover` operation of sidetree.

The following processes will be made:
- Create:
  -  When the call was sent to the sidetree node, VADE calls every second the did resolve function to check if the DID can be successfully resolved
- Update:
  - When the call was sent to the sidetree node, VADE calls every second the did resolve function to check if the DIDs `updateCommitment` changed to the value which was calculated beforehand
- Deactivate:
  - When the call was sent to the sidetree node, VADE calls every second the did resolve function to check if the DIDs `decativated` flag in the resolve is set to `true`
- Recover:
  - When the call was sent to the sidetree node, VADE calls every second the did resolve function to check if the DIDs `recoveryCommitment` changed to the value which was calculated beforehand`  