### PR TITLE
Adjust sidetree api to allow nonces and refactor input params

### DIFF
--- a/.github/test.yml
+++ b/.github/test.yml
@@ -1,0 +1,12 @@
+on: [push]
+
+name: Tests
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout vade-sidetree
+        uses: actions/checkout@v2
+      - name: Run cargo test
+        run: cargo test --release --all-features --no-fail-fast

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use vade_sidetree_client::{did::JsonWebKey, Delta, Patch, SuffixData};
+use vade_sidetree_client::{
+    did::{JsonWebKey, JsonWebKeyPublic},
+    Delta, Patch, SuffixData,
+};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all(serialize = "camelCase", deserialize = "camelCase"))]
@@ -64,7 +67,7 @@ pub struct KeyAgreement {
     pub controller: String,
     #[serde(rename = "type")]
     pub type_field: String,
-    pub public_key_jwk: JsonWebKey,
+    pub public_key_jwk: JsonWebKeyPublic,
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
@@ -97,8 +100,8 @@ pub struct DidUpdatePayload {
     pub update_type: UpdateType,
     pub update_key: Option<JsonWebKey>,
     pub recovery_key: Option<JsonWebKey>,
-    pub next_update_key: Option<JsonWebKey>,
-    pub next_recovery_key: Option<JsonWebKey>,
+    pub next_update_key: Option<JsonWebKeyPublic>,
+    pub next_recovery_key: Option<JsonWebKeyPublic>,
     pub patches: Option<Vec<Patch>>,
 }
 

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use vade_sidetree_client::{
@@ -58,6 +60,8 @@ pub struct DidDocument {
     pub context: Value,
     pub verification_method: Option<Vec<KeyAgreement>>,
     pub service: Option<Vec<Service>>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -97,8 +97,8 @@ pub struct DidUpdatePayload {
     pub update_type: UpdateType,
     pub update_key: Option<JsonWebKey>,
     pub recovery_key: Option<JsonWebKey>,
-    pub update_commitment: Option<String>,
-    pub recovery_commitment: Option<String>,
+    pub next_update_key: Option<JsonWebKey>,
+    pub next_recovery_key: Option<JsonWebKey>,
     pub patches: Option<Vec<Patch>>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,6 @@
 //! [`VadeSidetree `]: https://git.slock.it/equs/interop/vade/vade-sidetree
 //! [`VadePlugin`]: https://docs.rs/vade/*/vade/trait.VadePlugin.html
 
-mod datatypes;
+pub mod datatypes;
 mod vade_sidetree;
 pub use self::vade_sidetree::*;

--- a/vade-sidetree-client/src/did.rs
+++ b/vade-sidetree-client/src/did.rs
@@ -36,6 +36,8 @@ pub struct JsonWebKey {
     pub y: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub d: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/vade-sidetree-client/src/did.rs
+++ b/vade-sidetree-client/src/did.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Document {
-    pub public_keys: Vec<PublicKey>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_keys: Option<Vec<PublicKey>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub services: Option<Vec<Service>>,
 }
@@ -17,6 +18,8 @@ pub struct Document {
 #[serde(rename_all = "camelCase")]
 pub struct PublicKey {
     pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub controller: Option<String>,
     #[serde(rename = "type")]
     pub key_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -27,13 +30,28 @@ pub struct PublicKey {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
+pub struct JsonWebKeyPublic {
+    #[serde(rename = "kty")]
+    pub key_type: String,
+    #[serde(rename = "crv")]
+    pub curve: String,
+    pub x: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub y: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct JsonWebKey {
     #[serde(rename = "kty")]
     pub key_type: String,
     #[serde(rename = "crv")]
     pub curve: String,
     pub x: String,
-    pub y: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub y: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub d: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/vade-sidetree-client/src/lib.rs
+++ b/vade-sidetree-client/src/lib.rs
@@ -1,4 +1,4 @@
-use did::{Document, JsonWebKey, PublicKey, Service};
+use did::{Document, JsonWebKey, JsonWebKeyPublic, PublicKey, Service};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -14,8 +14,6 @@ pub struct Delta {
 pub struct SuffixData {
     pub delta_hash: String,
     pub recovery_commitment: String,
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    pub data_type: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -29,7 +27,7 @@ pub struct SignedUpdateDataPayload {
 #[serde(rename_all = "camelCase")]
 pub struct SignedRecoveryDataPayload {
     pub delta_hash: String,
-    pub recovery_key: JsonWebKey,
+    pub recovery_key: JsonWebKeyPublic,
     pub recovery_commitment: String,
 }
 
@@ -37,7 +35,7 @@ pub struct SignedRecoveryDataPayload {
 #[serde(rename_all = "camelCase")]
 pub struct SignedDeactivateDataPayload {
     pub did_suffix: String,
-    pub recovery_key: JsonWebKey,
+    pub recovery_key: JsonWebKeyPublic,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/vade-sidetree-client/src/secp256k1.rs
+++ b/vade-sidetree-client/src/secp256k1.rs
@@ -67,6 +67,7 @@ impl From<&KeyPair> for JsonWebKey {
                 .secret_key
                 .as_ref()
                 .map(|secret_key| encode(secret_key.serialize())),
+            nonce: None,
         }
     }
 }

--- a/vade-sidetree-client/src/secp256k1.rs
+++ b/vade-sidetree-client/src/secp256k1.rs
@@ -1,7 +1,7 @@
 use secp256k1::{Message, PublicKey, RecoveryId, SecretKey, Signature};
 
 use crate::{
-    did::{JsonWebKey, Purpose},
+    did::{JsonWebKey, JsonWebKeyPublic, Purpose},
     encoder::encode,
 };
 
@@ -33,6 +33,7 @@ impl KeyPair {
 
         crate::PublicKey {
             id,
+            controller: None,
             key_type: "EcdsaSecp256k1VerificationKey2019".to_string(),
             purposes,
             public_key_jwk: Some(jwk),
@@ -62,12 +63,38 @@ impl From<&KeyPair> for JsonWebKey {
             key_type: "EC".into(),
             curve: "secp256k1".into(),
             x: encode(serialized_public_key[1..33].as_ref()),
-            y: encode(serialized_public_key[33..65].as_ref()),
+            y: Some(encode(serialized_public_key[33..65].as_ref())),
             d: keypair
                 .secret_key
                 .as_ref()
                 .map(|secret_key| encode(secret_key.serialize())),
             nonce: None,
+        }
+    }
+}
+
+impl From<&KeyPair> for JsonWebKeyPublic {
+    fn from(keypair: &KeyPair) -> Self {
+        let serialized_public_key = keypair.public_key.serialize();
+
+        JsonWebKeyPublic {
+            key_type: "EC".into(),
+            curve: "secp256k1".into(),
+            x: encode(serialized_public_key[1..33].as_ref()),
+            y: Some(encode(serialized_public_key[33..65].as_ref())),
+            nonce: None,
+        }
+    }
+}
+
+impl From<&JsonWebKey> for JsonWebKeyPublic {
+    fn from(key: &JsonWebKey) -> Self {
+        JsonWebKeyPublic {
+            key_type: "EC".into(),
+            curve: "secp256k1".into(),
+            x: key.x.clone(),
+            y: key.y.clone(),
+            nonce: key.nonce.clone(),
         }
     }
 }


### PR DESCRIPTION
This PR adjusts the whole Sidetree api by passing only the public/private keys for the update/recover/deactivate functions and the logic in vade-sidetree then calculates the commitments then.

Also it allows setting the `nonce` property in the public keys when passing them as "next" keys.

Additionally, we now allow setting publicKeys and services directly when creating a did.