### PR TITLE
Fix in3 request list fallback payload

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -8,6 +8,8 @@
 
 ### Fixes
 
+- fix in3 request list fallback payload
+
 ### Deprecations
 
 ## v0.0.3

--- a/src/in3_request_list.rs
+++ b/src/in3_request_list.rs
@@ -28,7 +28,7 @@ pub fn send_request(
     let path = CString::new("")?;
     let path = path.as_ptr();
 
-    let payload = CString::new(payload.ok_or("")?)?;
+    let payload = CString::new(payload.unwrap_or("")?)?;
     let payload = payload.as_ptr();
 
     let mut res: *mut c_char = std::ptr::null_mut();


### PR DESCRIPTION
Fixes fallback value to be able to use run without payload value properly.

## Details

- by using empty string instead of returning an error (`ok_or` -> `unwrap_or`)