### PR TITLE
Export types from sidetree client 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,7 +778,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand 0.7.3",
+ "rand",
  "serde",
  "sha2",
  "typenum",

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,6 +6,7 @@
 
 - add support for passing keys to DID creation
 - add new flag `waitForCompletion` to the creation and update process
+- export sidetree-client module
 
 ### Fixes
 

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -6,10 +6,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 #[cfg(feature = "sdk")]
 use std::os::raw::c_void;
+#[allow(unused_imports)]
 use vade_sidetree_client::{
-    did::{JsonWebKey, JsonWebKeyPublic},
-    Delta, Patch, SuffixData,
+    did::{JsonWebKey, JsonWebKeyPublic, PublicKey, Purpose, Service},
+    Delta, Patch, SuffixData, AddPublicKeys, AddServices, RemovePublicKeys, RemoveServices,
 };
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all(serialize = "camelCase", deserialize = "camelCase"))]
 pub enum UpdateType {
@@ -96,14 +98,14 @@ pub struct MethodMetadata {
     pub update_commitment: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Service {
-    pub id: String,
-    #[serde(rename = "type")]
-    pub type_field: String,
-    pub service_endpoint: String,
-}
+// #[derive(Default, Debug, Clone, Serialize, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// pub struct Service {
+//     pub id: String,
+//     #[serde(rename = "type")]
+//     pub type_field: String,
+//     pub service_endpoint: String,
+// }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 #[cfg(feature = "sdk")]
 use std::os::raw::c_void;
-#[allow(unused_imports)]
-use vade_sidetree_client::{
+
+pub use vade_sidetree_client::{
     did::{JsonWebKey, JsonWebKeyPublic, PublicKey, Purpose, Service},
     Delta, Patch, SuffixData, AddPublicKeys, AddServices, RemovePublicKeys, RemoveServices,
 };

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -9,7 +9,7 @@ use std::os::raw::c_void;
 
 pub use vade_sidetree_client::{
     did::{JsonWebKey, JsonWebKeyPublic, PublicKey, Purpose, Service},
-    Delta, Patch, SuffixData, AddPublicKeys, AddServices, RemovePublicKeys, RemoveServices,
+    AddPublicKeys, AddServices, Delta, Patch, RemovePublicKeys, RemoveServices, SuffixData,
 };
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -97,15 +97,6 @@ pub struct MethodMetadata {
     pub recovery_commitment: Option<String>,
     pub update_commitment: Option<String>,
 }
-
-// #[derive(Default, Debug, Clone, Serialize, Deserialize)]
-// #[serde(rename_all = "camelCase")]
-// pub struct Service {
-//     pub id: String,
-//     #[serde(rename = "type")]
-//     pub type_field: String,
-//     pub service_endpoint: String,
-// }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -7,10 +7,7 @@ use serde_json::Value;
 #[cfg(feature = "sdk")]
 use std::os::raw::c_void;
 
-pub use vade_sidetree_client::{
-    did::{JsonWebKey, JsonWebKeyPublic, PublicKey, Purpose, Service},
-    AddPublicKeys, AddServices, Delta, Patch, RemovePublicKeys, RemoveServices, SuffixData,
-};
+pub use vade_sidetree_client::{did::*, *};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all(serialize = "camelCase", deserialize = "camelCase"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,11 @@
 //! [`VadePlugin`]: https://docs.rs/vade/*/vade/trait.VadePlugin.html
 
 pub mod datatypes;
-mod vade_sidetree;
 #[cfg(feature = "sdk")]
 mod in3_request_list;
+mod vade_sidetree;
 pub use self::vade_sidetree::*;
-pub use vade_sidetree_client::*;
+pub use vade_sidetree_client::{
+    did::{JsonWebKey, JsonWebKeyPublic, PublicKey, Purpose, Service},
+    AddPublicKeys, AddServices, Patch, RemovePublicKeys, RemoveServices,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,3 +43,4 @@ mod vade_sidetree;
 #[cfg(feature = "sdk")]
 mod in3_request_list;
 pub use self::vade_sidetree::*;
+pub use vade_sidetree_client::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,3 @@ pub mod datatypes;
 mod in3_request_list;
 mod vade_sidetree;
 pub use self::vade_sidetree::*;
-pub use vade_sidetree_client::{
-    did::{JsonWebKey, JsonWebKeyPublic, PublicKey, Purpose, Service},
-    AddPublicKeys, AddServices, Patch, RemovePublicKeys, RemoveServices,
-};


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Exported sidetree-client 

## Details 

- exported sidetree client
- updated versions.md

<!--- HOW does it change stuff? -->

## Impact on other parties

<!-- Delete points, that do not apply. Add comments to those that apply. -->
- vade-evan and other projects depending on vade-sidetree can access types from sidetree-client , this will reduce redundancy of defining types twice

